### PR TITLE
Add GitHub Action to build Windows releases

### DIFF
--- a/.github/workflows/build-linux-binary.yml
+++ b/.github/workflows/build-linux-binary.yml
@@ -47,17 +47,30 @@ jobs:
           name: Release v${{ steps.get_version.outputs.VERSION }}
           body: |
             Release of version ${{ steps.get_version.outputs.VERSION }}
-            
+
             ## Linux Binary
             Download the Linux AMD64 binary from the assets below.
-            
-            ## Installation
+
+            ### Installation (Linux)
             ```bash
             # Download and extract
             curl -L -o bld-linux-amd64.zip https://github.com/buildio/cli/releases/download/v${{ steps.get_version.outputs.VERSION }}/bld-linux-amd64.zip
             unzip bld-linux-amd64.zip
             chmod +x bld
             sudo mv bld /usr/local/bin/
+            ```
+
+            ## Windows Binary
+            Download the Windows AMD64 binary from the assets below.
+
+            ### Installation (Windows)
+            ```powershell
+            # Download and extract
+            Invoke-WebRequest -Uri "https://github.com/buildio/cli/releases/download/v${{ steps.get_version.outputs.VERSION }}/bld-windows-amd64.zip" -OutFile "bld-windows-amd64.zip"
+            Expand-Archive -Path bld-windows-amd64.zip -DestinationPath .
+
+            # Move to a directory in your PATH (example: C:\Program Files\bld)
+            # Or add the current directory to your PATH
             ```
           files: |
             bin/linux-amd64/bld-linux-amd64.zip

--- a/.github/workflows/build-windows-binary.yml
+++ b/.github/workflows/build-windows-binary.yml
@@ -1,0 +1,67 @@
+name: Build Windows Binary
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to build (e.g., 1.1.6)'
+        required: true
+        type: string
+
+jobs:
+  build-windows-binary:
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Crystal
+        run: |
+          iwr -useb get.scoop.sh -outfile 'install-scoop.ps1'
+          .\install-scoop.ps1 -RunAsAdmin
+          scoop install crystal
+          crystal --version
+        shell: powershell
+
+      - name: Install dependencies
+        run: |
+          shards check || shards install --production --frozen
+        shell: powershell
+
+      - name: Build Windows binary
+        run: |
+          mkdir -p bin/windows-amd64
+          crystal build src/build_cli.cr --release --no-debug -o bin/windows-amd64/bld.exe
+        shell: powershell
+
+      - name: Get version
+        id: get_version
+        run: |
+          if ("${{ github.event_name }}" -eq "workflow_dispatch") {
+            echo "VERSION=${{ github.event.inputs.version }}" >> $env:GITHUB_OUTPUT
+          } else {
+            $tag = "${{ github.ref }}" -replace 'refs/tags/v', ''
+            echo "VERSION=$tag" >> $env:GITHUB_OUTPUT
+          }
+        shell: powershell
+
+      - name: Create release zip
+        run: |
+          Compress-Archive -Path bin/windows-amd64/bld.exe -DestinationPath bin/windows-amd64/bld-windows-amd64.zip
+        shell: powershell
+
+      - name: Upload Windows binary to release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: v${{ steps.get_version.outputs.VERSION }}
+          files: |
+            bin/windows-amd64/bld-windows-amd64.zip
+          draft: false
+          prerelease: false
+          fail_on_unmatched_files: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

This PR adds Windows support to the CLI release process by introducing a new GitHub Actions workflow that builds Windows binaries.

## Changes

- **New Windows workflow** (`.github/workflows/build-windows-binary.yml`):
  - Uses `windows-latest` runner with Crystal installed via Scoop
  - Builds native Windows AMD64 binary (`bld.exe`)
  - Packages as `bld-windows-amd64.zip`
  - Uploads to GitHub releases alongside Linux binaries
  - Triggers on version tags (`v*`) and manual workflow dispatch

- **Updated Linux workflow** (`.github/workflows/build-linux-binary.yml`):
  - Added Windows installation instructions to release notes
  - Both Linux and Windows platforms documented in every release

## How It Works

When a version tag is pushed (e.g., `v1.1.14`):
1. Both Linux and Windows workflows trigger automatically
2. Linux workflow creates the release with documentation for both platforms
3. Windows workflow adds the Windows binary to the same release
4. Users can download binaries for their platform from the releases page

## Testing

The Windows workflow can be tested by:
- Triggering manually via workflow dispatch
- Pushing a test tag after merge

## Platform Support

After this PR, the CLI will officially support:
- ✅ Linux AMD64 (existing)
- ✅ Windows AMD64 (new)

The code already has Windows-specific logic (e.g., browser launch commands), but previously lacked a build/release pipeline.