### PR TITLE
Add --zone option to logs command

### DIFF
--- a/src/commands/logs.cr
+++ b/src/commands/logs.cr
@@ -14,6 +14,7 @@ module Build
           .option("tail", "t", :none, "Tail the logs.")
           .option("count", "c", :optional, "Number of lines to display.")
           .option("source", "s", :optional, "The log source to display from (app or build).")
+          .option("zone", "z", :optional, "The zone to retrieve logs from.")
       end
 
       protected def execute(input : ACON::Input::Interface, output : ACON::Output::Interface) : ACON::Command::Status
@@ -35,6 +36,8 @@ module Build
         query_params["num"] = num if num
         source = input.option("source")
         query_params["source"] = source if source
+        zone = input.option("zone")
+        query_params["zone"] = zone if zone
 
         user_token = Netrc.read[Build.api_host].try &.password
         if user_token.nil?


### PR DESCRIPTION
## Summary
- Adds a new `--zone` / `-z` option to the `logs` command
- Allows users to specify which zone to retrieve logs from

## Test plan
- [ ] Run `logs --zone <zone>` and verify logs are retrieved from the specified zone
- [ ] Verify the option appears in `logs --help`

🤖 Generated with [Claude Code](https://claude.com/claude-code)