### PR TITLE
Fix config type: use Hash(String, String) to match SDK

### DIFF
--- a/src/commands/addons.cr
+++ b/src/commands/addons.cr
@@ -92,12 +92,12 @@ module Build
           config_opts = input.option("config", type: Array(String))
           json_output = input.option("json", type: Bool)
 
-          config = nil.as(Hash(String, Object)?)
+          config = nil.as(Hash(String, String)?)
           unless config_opts.empty?
-            config = Hash(String, Object).new
+            config = Hash(String, String).new
             config_opts.each do |opt|
               k, _, v = opt.partition('=')
-              config.not_nil![k] = v.as(Object)
+              config.not_nil![k] = v
             end
           end
 


### PR DESCRIPTION
## Summary

Changes the addon config type from Hash(String, Object)? to Hash(String, String)? to match the updated SDK type.

## Background

The SDK was generating Hash(String, Object)? for the config field, but Crystal does not support Object as a generic type parameter.

The API spec was updated to use additionalProperties: { type: :string }, which makes the SDK generate Hash(String, String)? instead.

## Dependencies

This PR should be merged AFTER the SDK is regenerated with the new type (Hash(String, String)?).