### PR TITLE
Display human_name in addons:info output

### DIFF
--- a/src/commands/addons.cr
+++ b/src/commands/addons.cr
@@ -153,6 +153,9 @@ module Build
               parsed = JSON.parse(data)
               name = parsed["name"]?.try(&.as_s?) || parsed["id"].as_s
               output.puts "=== #{name}"
+              if human_name = parsed["human_name"]?.try(&.as_s?)
+                output.puts "Display Name: #{human_name}" unless human_name.empty?
+              end
               if desc = parsed["description"]?.try(&.as_s?)
                 output.puts "Description:  #{desc}" unless desc.empty?
               end


### PR DESCRIPTION
## Summary
Shows the `human_name` (display name) field in `addons:info` output when present.

Depends on antimony PR #1036 which adds `human_name` to the API response.

## Example output
```
=== my-addon
Display Name: My Friendly Addon Name
Description:  Some description
Plan:         essential-0
...
```