### PR TITLE
Fix Windows build: guard Signal::WINCH with win32 flag

### DIFF
--- a/src/commands/ps.cr
+++ b/src/commands/ps.cr
@@ -274,11 +274,13 @@ module Build
           terminal = ACON::Terminal.new
           self.send_cable(ws, identifier, {type: "resize", cols: terminal.width, rows: terminal.height})
 
-          # Handle terminal resize
-          Signal::WINCH.trap do
-            t = ACON::Terminal.new
-            self.send_cable(ws, identifier, {type: "resize", cols: t.width, rows: t.height}) rescue nil
-          end
+          # Handle terminal resize (SIGWINCH is Unix-only)
+          {% unless flag?(:win32) %}
+            Signal::WINCH.trap do
+              t = ACON::Terminal.new
+              self.send_cable(ws, identifier, {type: "resize", cols: t.width, rows: t.height}) rescue nil
+            end
+          {% end %}
 
           # Enter raw mode and stream stdin
           STDIN.noecho do


### PR DESCRIPTION
## Summary
- Wraps `Signal::WINCH.trap` in `{% unless flag?(:win32) %}` in `ps.cr`, fixing the compile error on Windows (`undefined constant Signal::WINCH`)
- Matches the existing platform guard pattern already used in `run.cr`

## Test plan
- [x] `crystal spec` passes (43 examples, 0 failures)
- [x] `crystal build --no-codegen` passes
- [ ] Verify Windows CI build succeeds