### PR TITLE
Fix SSH session degradation: switch ssh2 to upstream

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -29,8 +29,8 @@ shards:
     version: 0.1.0+git.commit.668cac882b4ba9ce3c2ce3a6a92e7331d8afe9d8
 
   ssh2:
-    git: https://github.com/usiegj00/ssh2.cr.git
-    version: 1.7.1+git.commit.064d72e261fdd32e4b367c3708ae69af555836c9
+    git: https://github.com/spider-gazelle/ssh2.cr.git
+    version: 1.7.2
 
   term-cursor:
     git: https://github.com/crystal-term/cursor.git

--- a/shard.yml
+++ b/shard.yml
@@ -15,7 +15,8 @@ dependencies:
   netrc:
     github: usiegj00/crystal-netrc
   ssh2:
-    github: usiegj00/ssh2.cr
+    github: spider-gazelle/ssh2.cr
+    version: "~> 1.7.2"
   athena-console:
     github: athena-framework/console
     version: "~> 0.3.5"


### PR DESCRIPTION
## Summary
- Our fork (`usiegj00/ssh2.cr`) had exactly one divergent commit (`064d72e`) that introduced a fiber leak in `waitsocket` for Crystal 1.16+
- Every `EAGAIN` spawned a new fiber + unbuffered channel; timed-out fibers blocked forever, accumulating and choking the event loop
- Upstream `spider-gazelle/ssh2.cr` v1.7.2 already has the correct fix (direct event loop calls, no fiber spawning)
- Switch back to upstream, drop the fork

Fixes #12

## Test plan
- [x] `crystal spec` — 43 examples, 0 failures
- [x] `crystal build` compiles clean
- [ ] Manual: `bld run bash -a <app>` stays responsive over extended session