### PR TITLE
Add addons:services, addons:plans, ps:scale commands

### DIFF
--- a/src/build_cli.cr
+++ b/src/build_cli.cr
@@ -83,6 +83,7 @@ application.add Build::Commands::Config::Delete.new
 
 application.add Build::Commands::Process::List.new
 application.add Build::Commands::Process::Delete.new
+application.add Build::Commands::Process::Scale.new
 application.add Build::Commands::Process::Exec.new
 
 application.add Build::Commands::Pipeline::List.new
@@ -90,6 +91,8 @@ application.add Build::Commands::Pipeline::Info.new
 
 # Addon management commands
 application.add Build::Commands::Addons::List.new
+application.add Build::Commands::Addons::Services.new
+application.add Build::Commands::Addons::Plans.new
 application.add Build::Commands::Addons::Create.new
 application.add Build::Commands::Addons::Info.new
 application.add Build::Commands::Addons::Destroy.new

--- a/src/commands/addons.cr
+++ b/src/commands/addons.cr
@@ -69,6 +69,108 @@ module Build
         end
       end
 
+      @[ACONA::AsCommand("addons:services")]
+      class Services < Base
+        protected def configure : Nil
+          self
+            .name("addons:services")
+            .description("List available addon services.")
+            .option("json", "j", :none, "Output in JSON format.")
+            .help("List all available addon services from the catalog.")
+        end
+
+        protected def execute(input : ACON::Input::Interface, output : ACON::Output::Interface) : ACON::Command::Status
+          json_output = input.option("json", type: Bool)
+
+          begin
+            api
+            data = self.fetch_services
+            if json_output
+              output.puts data
+            else
+              parsed = JSON.parse(data)
+              headers = {"slug", "name", "state"}
+              rows = parsed.as_a.map do |svc|
+                {svc["name"].as_s, svc["human_name"]?.try(&.as_s?) || svc["name"].as_s, svc["state"]?.try(&.as_s?) || ""}
+              end
+              print_table(output, headers, rows)
+            end
+            return ACON::Command::Status::SUCCESS
+          rescue e : Build::ApiError
+            output.puts "<error>Failed to list addon services: #{e.message}</error>"
+            return ACON::Command::Status::FAILURE
+          end
+        end
+
+        private def fetch_services : String
+          path = "/api/v1/addon-services"
+          api_client = Build::ApiClient.default
+          header_params = Hash(String, String).new
+          header_params["Accept"] = "application/json"
+          auth_names = ["bearer", "oauth2"]
+          data, _status, _headers = api_client.call_api(:GET, path,
+            :"AddonServicesApi.index", "String", nil, auth_names,
+            header_params, Hash(String, String).new, Hash(String, String).new,
+            Hash(Symbol, (String | ::File)).new)
+          data
+        end
+      end
+
+      @[ACONA::AsCommand("addons:plans")]
+      class Plans < Base
+        protected def configure : Nil
+          self
+            .name("addons:plans")
+            .description("List plans for an addon service.")
+            .argument("service", :required, "Addon service name (e.g. bld-postgres).")
+            .option("json", "j", :none, "Output in JSON format.")
+            .help("List available plans for an addon service.")
+        end
+
+        protected def execute(input : ACON::Input::Interface, output : ACON::Output::Interface) : ACON::Command::Status
+          service_name = input.argument("service", type: String)
+          json_output = input.option("json", type: Bool)
+
+          begin
+            api
+            data = self.fetch_plans(service_name)
+            if json_output
+              output.puts data
+            else
+              parsed = JSON.parse(data)
+              headers = {"default", "slug", "name", "price"}
+              rows = parsed.as_a.map do |plan|
+                is_default = plan["default"]?.try(&.as_bool?) ? "default" : ""
+                slug = "#{service_name}:#{plan["name"].as_s}"
+                human = plan["human_name"]?.try(&.as_s?) || plan["name"].as_s
+                cents = plan["monthly_price"]?.try(&.["cents"]?.try(&.as_i?))
+                unit = plan["monthly_price"]?.try(&.["unit"]?.try(&.as_s?))
+                price = (cents && unit) ? "$#{"%.2f" % (cents / 100.0)}/#{unit}" : ""
+                {is_default, slug, human, price}
+              end
+              print_table(output, headers, rows)
+            end
+            return ACON::Command::Status::SUCCESS
+          rescue e : Build::ApiError
+            output.puts "<error>Failed to list plans: #{e.message}</error>"
+            return ACON::Command::Status::FAILURE
+          end
+        end
+
+        private def fetch_plans(service_name : String) : String
+          path = "/api/v1/addon-services/#{URI.encode_path(service_name)}/plans"
+          api_client = Build::ApiClient.default
+          header_params = Hash(String, String).new
+          header_params["Accept"] = "application/json"
+          auth_names = ["bearer", "oauth2"]
+          data, _status, _headers = api_client.call_api(:GET, path,
+            :"AddonServicesApi.plans", "String", nil, auth_names,
+            header_params, Hash(String, String).new, Hash(String, String).new,
+            Hash(Symbol, (String | ::File)).new)
+          data
+        end
+      end
+
       @[ACONA::AsCommand("addons:create")]
       class Create < Base
         protected def configure : Nil
@@ -122,7 +224,26 @@ module Build
             end
             return ACON::Command::Status::SUCCESS
           rescue e : Build::ApiError
-            output.puts "<error>Failed to create addon: #{e.message}</error>"
+            # Try to parse structured error response for actionable suggestions
+            if body = e.message
+              begin
+                parsed = JSON.parse(body)
+                msg = parsed["message"]?.try(&.as_s?) || body
+                output.puts "<error>#{msg}</error>"
+                if plans = parsed["available_plans"]?
+                  plan_list = plans.as_a.map(&.as_s).join(", ")
+                  output.puts "Available plans: #{plan_list}"
+                  service_name = plan.split(":").first?
+                  output.puts "Run 'bld addons:plans #{service_name}' to see plan details." if service_name
+                elsif hint = parsed["hint"]?.try(&.as_s?)
+                  output.puts "Run 'bld addons:services' to see available services."
+                end
+              rescue JSON::ParseException
+                output.puts "<error>Failed to create addon: #{e.message}</error>"
+              end
+            else
+              output.puts "<error>Failed to create addon</error>"
+            end
             return ACON::Command::Status::FAILURE
           end
         end

--- a/src/commands/base.cr
+++ b/src/commands/base.cr
@@ -30,6 +30,18 @@ module Build
         # Configure the API client
         @api_instance = Build::DefaultApi.new
       end
+
+      def print_table(output : ACON::Output::Interface, headers : Tuple, rows : Array(Tuple))
+        widths = Array(Int32).new(headers.size, 0)
+        headers.each_with_index { |h, i| widths[i] = {widths[i], h.size}.max }
+        rows.each do |row|
+          row.each_with_index { |val, i| widths[i] = {widths[i], val.size}.max if i < widths.size }
+        end
+        fmt = widths.map_with_index { |w, i| i == widths.size - 1 ? "%s" : "%-#{w}s" }.join("  ")
+        output.puts fmt % headers
+        output.puts widths.map { |w| "─" * w }.join("  ")
+        rows.each { |row| output.puts fmt % row }
+      end
     end
   end
 end

--- a/src/commands/ps.cr
+++ b/src/commands/ps.cr
@@ -105,6 +105,128 @@ module Build
           return ACON::Command::Status::SUCCESS
         end
       end
+      @[ACONA::AsCommand("ps:scale")]
+      class Scale < Base
+        protected def configure : Nil
+          self
+            .name("ps:scale")
+            .description("Scale process formation")
+            .option("app", "a", :required, "The ID or NAME of the application")
+            .option("json", "j", :none, "Output in JSON format")
+            .argument("args", ACON::Input::Argument::Mode[:optional, :is_array], "TYPE=QUANTITY[:SIZE] pairs (e.g. web=2:Standard-2X worker=1)")
+            .help("Scale process types. With no arguments, shows current formation.\n\nExamples:\n  ps:scale -a myapp web=2\n  ps:scale -a myapp web=2:Standard-2X worker=1")
+        end
+
+        protected def execute(input : ACON::Input::Interface, output : ACON::Output::Interface) : ACON::Command::Status
+          app_name_or_id = input.option("app", type: String)
+          json_output = input.option("json", type: Bool?) || false
+          scale_args = input.argument("args", type: Array(String))
+
+          if app_name_or_id.blank?
+            output.puts("<error>Missing required option --app</error>")
+            return ACON::Command::Status::FAILURE
+          end
+
+          if scale_args.empty?
+            return show_formation(app_name_or_id, json_output, output)
+          end
+
+          updates = Array(Hash(String, String | Int32)).new
+          scale_args.each do |arg|
+            type_part, _, rest = arg.partition('=')
+            if rest.empty?
+              output.puts("<error>Invalid argument '#{arg}'. Use TYPE=QUANTITY[:SIZE]</error>")
+              return ACON::Command::Status::FAILURE
+            end
+            qty_part, _, size_part = rest.partition(':')
+            qty = qty_part.to_i?
+            unless qty
+              output.puts("<error>Invalid quantity '#{qty_part}' in '#{arg}'</error>")
+              return ACON::Command::Status::FAILURE
+            end
+            update = Hash(String, String | Int32).new
+            update["type"] = type_part
+            update["quantity"] = qty
+            update["size"] = size_part unless size_part.empty?
+            updates << update
+          end
+
+          begin
+            api
+            data = scale_formation(app_name_or_id, updates)
+            if json_output
+              output.puts data
+            else
+              parsed = JSON.parse(data)
+              entries = parsed.as_a? || parsed.as_h.values.find(&.as_a?).try(&.as_a) || [parsed]
+              entries.each do |entry|
+                type = entry["type"]?.try(&.as_s?) || next
+                qty = entry["quantity"]?.try(&.as_i?) || next
+                size = entry["size"]?.try(&.as_s?) || ""
+                label = size.empty? ? "#{type}=#{qty}" : "#{type}=#{qty}:#{size}"
+                output.puts "Scaling #{label}... done"
+              end
+            end
+            return ACON::Command::Status::SUCCESS
+          rescue e : Build::ApiError
+            output.puts "<error>Failed to scale: #{e.message}</error>"
+            return ACON::Command::Status::FAILURE
+          end
+        end
+
+        private def show_formation(app_id : String, json_output : Bool, output : ACON::Output::Interface) : ACON::Command::Status
+          begin
+            api
+            data = fetch_formation(app_id)
+            if json_output
+              output.puts data
+            else
+              parsed = JSON.parse(data)
+              entries = parsed.as_a? || parsed.as_h.values.find(&.as_a?).try(&.as_a) || [parsed]
+              entries.each do |entry|
+                type = entry["type"]?.try(&.as_s?) || next
+                qty = entry["quantity"]?.try(&.as_i?) || next
+                size = entry["size"]?.try(&.as_s?) || ""
+                label = size.empty? ? "#{type}=#{qty}" : "#{type}=#{qty}:#{size}"
+                output.puts label
+              end
+            end
+            return ACON::Command::Status::SUCCESS
+          rescue e : Build::ApiError
+            output.puts "<error>Failed to get formation: #{e.message}</error>"
+            return ACON::Command::Status::FAILURE
+          end
+        end
+
+        private def fetch_formation(app_id : String) : String
+          path = "/api/v1/apps/#{URI.encode_path(app_id)}/formation"
+          api_client = Build::ApiClient.default
+          header_params = Hash(String, String).new
+          header_params["Accept"] = "application/json"
+          auth_names = ["bearer", "oauth2"]
+          data, _status, _headers = api_client.call_api(:GET, path,
+            :"FormationApi.list", "String", nil, auth_names,
+            header_params, Hash(String, String).new, Hash(String, String).new,
+            Hash(Symbol, (String | ::File)).new)
+          data
+        end
+
+        private def scale_formation(app_id : String, updates : Array(Hash(String, String | Int32))) : String
+          path = "/api/v1/apps/#{URI.encode_path(app_id)}/formation"
+          api_client = Build::ApiClient.default
+          header_params = Hash(String, String).new
+          header_params["Accept"] = "application/json"
+          header_params["Content-Type"] = "application/json"
+          auth_names = ["bearer", "oauth2"]
+          body = {"updates" => updates}.to_json
+          data, _status, _headers = api_client.call_api(:PATCH, path,
+            :"FormationApi.batch_update", "String", body, auth_names,
+            header_params, Hash(String, String).new, Hash(String, String).new,
+            Hash(Symbol, (String | ::File)).new)
+          data
+        end
+      end
+
       @[ACONA::AsCommand("ps:exec")]
       class Exec < Base
         protected def configure : Nil


### PR DESCRIPTION
## Summary
- **addons:services** — list available addon services from the catalog API
- **addons:plans SERVICE** — list plans with pricing, Heroku-compatible table format
- **addons:create** — improved error handling: parses structured API errors, suggests available plans/services
- **ps:scale** — scale process formation with `TYPE=QTY[:SIZE]` syntax; shows current formation with no args
- Shared `print_table` helper in Base for columnar output with headers and separators

Closes #16, closes #17

## Test plan
- [x] `bld addons:services` shows columnar output with headers
- [x] `bld addons:plans ave-to-go` shows plans with pricing
- [x] `bld addons:services --json` / `bld addons:plans --json` return raw JSON
- [x] `bld ps:scale -a APP` shows current formation
- [x] `bld ps:scale -a APP worker=2` scales formation
- [ ] CI build passes