### PR TITLE
Fix pipelines:diff and promote missing --app guard

### DIFF
--- a/src/commands/pipelines.cr
+++ b/src/commands/pipelines.cr
@@ -139,16 +139,26 @@ module Build
         protected def configure : Nil
           self
             .name("pipelines:diff")
+            .argument("apps", :is_array, "Source app (and optional target app)", [] of String)
             .option("app", "a", :required, "Source app to compare")
             .option("json", "j", :none, "Output in JSON format")
             .description("compares the latest release of this app to its downstream app(s)")
-            .help("Shows commit differences between a source app and its downstream pipeline targets.\n\nExamples:\n  bld pipelines:diff -a my-app-staging")
+            .help("Shows commit differences between a source app and its downstream pipeline targets.\n\nExamples:\n  bld pipelines:diff -a my-app-staging\n  bld pipelines:diff my-app-staging")
         end
 
         protected def execute(input : ACON::Input::Interface, output : ACON::Output::Interface) : ACON::Command::Status
           api
           json_mode = input.option("json", type: Bool)
-          app_name = input.option("app", type: String)
+          # Support both: -a app-name OR positional arg
+          app_name = input.option("app", type: String?) rescue nil
+          if app_name.nil? || app_name.empty?
+            args = input.argument("apps", type: Array(String)) rescue [] of String
+            app_name = args.first? || ""
+          end
+          if app_name.empty?
+            output.puts ">".colorize(:red).to_s + "   Error: specify an app with --app (-a) or as a positional argument"
+            return ACON::Command::Status::FAILURE
+          end
 
           spinner = dots_spinner("Fetching diff")
           app = self.api.app(app_name)
@@ -253,7 +263,11 @@ module Build
           api
           json_mode = input.option("json", type: Bool)
           no_wait = input.option("no-wait", type: Bool)
-          app_name = input.option("app", type: String)
+          app_name = input.option("app", type: String?) rescue nil
+          if app_name.nil? || app_name.empty?
+            output.puts ">".colorize(:red).to_s + "   Error: specify an app with --app (-a)"
+            return ACON::Command::Status::FAILURE
+          end
           to_flag = input.option("to", type: String?) rescue nil
 
           # Resolve source app and its pipeline


### PR DESCRIPTION
## Summary
- Guards against missing `--app` in both `pipelines:diff` and `pipelines:promote`
- Adds positional arg support to `pipelines:diff` so both forms work:
  - `bld pipelines:diff -a my-app-staging`
  - `bld pipelines:diff my-app-staging`

## Root cause
Athena Console `:required` on an option means "value required **when the flag is used**" — the flag itself is always optional. Without `-a`, `app_name` is nil, `api.app(nil)` hits `/api/v1/apps/` (list endpoint), returns an array, and crashes:
```
Error: Expected BeginObject but was BeginArray at line 1, column 2
```

## Test plan
- [ ] `bld pipelines:diff my-app` works (positional arg)
- [ ] `bld pipelines:diff -a my-app` works (flag)
- [ ] `bld pipelines:diff` with no args shows clear error
- [ ] `bld pipelines:promote` with no `-a` shows clear error