### PR TITLE
Fix login failures on non-tty stdin and missing browser launchers

### DIFF
--- a/src/commands/login.cr
+++ b/src/commands/login.cr
@@ -36,7 +36,9 @@ module Build
         frames  = cyan + magenta
         spinner = Term::Spinner.new(":spinner Waiting for login", frames: frames, format: :dots, success_mark: "✓".colorize(:green).to_s, error_mark: "✗".colorize(:red).to_s)
         spinner.auto_spin # Automatic animation with default interval
-        launch_browser(oauth_url)
+        unless launch_browser(oauth_url)
+          output.puts "Could not open a browser automatically. Please open the URL above manually to continue."
+        end
         # Loop:
         poll_interval = 1
         timeout_seconds = (5 * 60)

--- a/src/utils.cr
+++ b/src/utils.cr
@@ -1,18 +1,29 @@
 def prompt_any_key(prompt : String) : Char
   mark = "?".colorize(:light_blue)
   print "#{mark} #{prompt} "
+  unless STDIN.tty?
+    puts
+    return '\n'
+  end
   char = STDIN.raw &.read_char
   puts char
   char || 'q'
 end
-def launch_browser(url)
+def launch_browser(url) : Bool
   {% if flag?(:darwin) %}
-    Process.run("open #{url}", shell: true)
+    status = Process.run("open #{url}", shell: true, output: Process::Redirect::Close, error: Process::Redirect::Close)
+    status.success?
   {% elsif flag?(:win32) %}
-    Process.run("start #{url}", shell: true)
+    status = Process.run("start #{url}", shell: true, output: Process::Redirect::Close, error: Process::Redirect::Close)
+    status.success?
   {% elsif flag?(:unix) %}
-    Process.run("xdg-open #{url}", shell: true)
+    status = Process.run("xdg-open #{url}", shell: true, output: Process::Redirect::Close, error: Process::Redirect::Close)
+    status.success?
+  {% else %}
+    false
   {% end %}
+rescue
+  false
 end
 def dots_spinner(status = nil)
   frames = %w{⠙ ⠹ ⠸ ⠼ ⠴}


### PR DESCRIPTION
## Summary

Two small, orthogonal bug fixes in `bld login`. No new flags or features.

A primary motivation here is **agent / LLM harness usage** (Claude Code, Cursor, Aider, Forge, etc.). These harnesses run `bld login` on behalf of the user in a non-interactive subprocess (no TTY attached to stdin) and rely on the user simply clicking "Accept" in the browser the CLI launches. Today both halves of that flow are broken: the CLI crashes before it can print the OAuth URL because `STDIN.raw` raises on a non-tty, and even if it got past that, on a headless box it would silently hang for 5 minutes with no URL for the agent to surface to the user. After this PR, an agent can run `bld login` in its sandbox, the user gets the OAuth URL (auto-opened locally if a browser is available, otherwise printed for the agent to relay), clicks Accept, and the CLI's existing poll loop completes the handshake.

## Bugs fixed

1. **Non-interactive terminal crash** — `prompt_any_key` in `src/utils.cr:1-7` calls `STDIN.raw &.read_char`, which raises whenever stdin is not a TTY (agent harnesses, CI runners, piped input, `docker run` without `-it`, systemd units). This killed `bld login` at `src/commands/login.cr:22` before any work happened.
2. **Silent hang when no browser launcher** — `launch_browser` in `src/utils.cr:8-16` discarded the result of `Process.run`. On a headless host (agent sandbox, SSH, minimal container, missing `xdg-open`/`open`/`start`) the user was stuck at the spinner for the full 5-minute poll loop with no indication anything went wrong.

## Changes

- `src/utils.cr` — `prompt_any_key` skips `STDIN.raw` when stdin is not a TTY and returns a non-`q` char so the flow continues.
- `src/utils.cr` — `launch_browser` now returns `Bool` based on `Process::Status#success?`, captures child output, returns `false` on unsupported platforms, and rescues spawn errors.
- `src/commands/login.cr` — when `launch_browser` returns `false`, prints a single line telling the user to open the already-displayed OAuth URL manually, then continues into the existing poll loop unchanged. The URL printed at `src/commands/login.cr:29` is what the agent relays to the user.

## Verification

- `bld login </dev/null` no longer raises in `prompt_any_key` — this is the exact invocation shape an agent harness uses.
- On a host without a working browser launcher, the manual-open hint appears immediately instead of after 5 minutes of silence, giving the agent a clear URL to surface to the user.
- On a normal interactive desktop with a working browser launcher, behavior is identical to before.
- `shards build` succeeds.