### PR TITLE
Add -t/--team flag to pipelines:list

### DIFF
--- a/src/commands/pipelines.cr
+++ b/src/commands/pipelines.cr
@@ -9,15 +9,18 @@ module Build
           self
             .name("pipelines:list")
             .description("list your pipelines")
+            .option("team", "t", :required, "Filter by team name or ID")
             .option("json", "j", :none, "Output in JSON format")
-            .help("Lists pipelines accessible to the current user")
+            .help("Lists pipelines accessible to the current user.\n\nUse -t to filter by team.")
+            .usage("pipelines -t my-team")
             .aliases(["pipelines"])
         end
 
         protected def execute(input : ACON::Input::Interface, output : ACON::Output::Interface) : ACON::Command::Status
           api  # Ensure authentication is set up
+          team_filter = input.option("team", type: String?)
           pipelines_api = Build::PipelinesApi.new
-          pipelines = pipelines_api.list_pipelines.sort_by(&.name)
+          pipelines = pipelines_api.list_pipelines(team_id: team_filter).sort_by(&.name)
 
           if input.option("json", type: Bool)
             output.puts pipelines.to_json


### PR DESCRIPTION
## Summary

Add `-t`/`--team` flag to `pipelines:list` to filter by team name or ID.

Uses the `team_id` query parameter on `GET /api/v1/pipelines` (added in buildio/build#1460) via the SDK's `list_pipelines(team_id:)` method. SDK v1.1.35 already on main.

Usage: `bld pipelines -t my-team`

## Test plan

- [x] `shards build` compiles
- [x] `bld pipelines:list --help` shows `-t`/`--team` option
- [ ] `bld pipelines -t <team>` returns only that team's pipelines
- [ ] `bld pipelines` (no flag) returns all pipelines as before
