### PR TITLE
Show git URL in apps:create output

### DIFF
--- a/src/commands/app.cr
+++ b/src/commands/app.cr
@@ -111,8 +111,10 @@ module Build
           else
             output.puts "App created:"
             output.puts ""
-            output.puts "  Name: #{app.name}"
-            output.puts "  ID:   #{app.id}"
+            output.puts "  Name:    #{app.name}"
+            output.puts "  ID:      #{app.id}"
+            output.puts "  Git URL: #{app.git_url}" if app.git_url
+            output.puts "  Web URL: #{app.web_url}" if app.web_url
           end
           return ACON::Command::Status::SUCCESS
         end


### PR DESCRIPTION
## Summary

`apps:create` only printed the app **Name** and **ID** in its human-readable output, so creating an app didn't surface the git URL needed to deploy — users had to make a follow-up `bld apps:info -a APP -j` call. `create_app` already returns a full `App` (including `git_url`/`web_url`, the same fields `apps:info` displays), so this just prints them.

## Changes

- `apps:create` now prints `Git URL` and `Web URL` (when present) alongside Name/ID, matching `apps:info`.
- `--json` output is unchanged (it already included everything).

```
App created:

  Name:    my-app
  ID:      ...
  Git URL: https://git.build.io/my-app.git
  Web URL: https://my-app...
```

## Follow-up

A Heroku-style `git:remote` command (auto-wiring a `bld` remote) is tracked separately in #32.

Fixes #29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
