### PR TITLE
Fix typing lag in interactive run sessions

### DIFF
--- a/src/commands/run.cr
+++ b/src/commands/run.cr
@@ -138,6 +138,16 @@ module Build
             exit
           end
 
+          # Disable Nagle's algorithm on the SSH transport. Interactive shells
+          # send ~1 byte per keystroke; with Nagle on (the Crystal/ssh2 default)
+          # each small packet waits on the peer's delayed-ACK timer (~40ms+),
+          # which is the "lag while typing" users feel. OpenSSH sets TCP_NODELAY
+          # on interactive sessions for the same reason.
+          session.socket.as(TCPSocket).tcp_nodelay = true
+          if verbose
+            output.puts "TCP_NODELAY enabled on SSH socket"
+          end
+
           spinner.update(status: "Opening channel")
           if verbose
             output.puts "Opening SSH channel"
@@ -206,7 +216,9 @@ module Build
               STDIN.noecho do
                 STDIN.raw do
                   spawn do
-                    buffer = Bytes.new(1)
+                    # 4096 like the non-TTY path: read() returns on the first
+                    # byte (keystrokes still forward instantly) but batches pastes.
+                    buffer = Bytes.new(4096)
                     slice = buffer.to_slice
                     loop do
                       count = STDIN.read(slice)


### PR DESCRIPTION
Interactive `bld run` (e.g. `bld run rails c`) felt laggy per keystroke because
the SSH transport ran with Nagle's algorithm enabled (the Crystal/ssh2 default),
so each ~1-byte keystroke waited on the peer's delayed-ACK timer (~40ms+).
OpenSSH disables Nagle on interactive sessions for exactly this reason; this
sets `TCP_NODELAY` on the session socket after login.

Also bumps the interactive input buffer from 1 to 4096 bytes (matching the
existing non-TTY path) so pastes go in chunks rather than one tiny SSH packet
per byte. `read` still returns on the first available byte, so single-keystroke
latency is unchanged.

Testing: verified the Crystal `TCPSocket` default is Nagle-on and the cast is
safe; confirmed live that interactive typing is noticeably snappier; build +
spec pass. (The SSH path isn't unit-testable in CI without a live server.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)