### PR TITLE
Parse ps timestamps leniently to avoid crashing the listing

### DIFF
--- a/spec/time_format_spec.cr
+++ b/spec/time_format_spec.cr
@@ -1,0 +1,50 @@
+require "./spec_helper"
+require "../src/time_format"
+
+describe Build::TimeFormat do
+  describe ".parse?" do
+    it "parses the millisecond+Z form the API commonly emits" do
+      t = Build::TimeFormat.parse?("2024-01-15T10:30:00.123Z")
+      t.should_not be_nil
+      t.not_nil!.to_utc.should eq(Time.utc(2024, 1, 15, 10, 30, 0, nanosecond: 123_000_000))
+    end
+
+    it "parses timestamps without fractional seconds" do
+      Build::TimeFormat.parse?("2024-01-15T10:30:00Z").try(&.to_utc)
+        .should eq(Time.utc(2024, 1, 15, 10, 30, 0))
+    end
+
+    it "parses microsecond precision" do
+      Build::TimeFormat.parse?("2024-01-15T10:30:00.123456Z").should_not be_nil
+    end
+
+    it "parses a numeric UTC offset instead of Z" do
+      Build::TimeFormat.parse?("2024-01-15T10:30:00+00:00").try(&.to_utc)
+        .should eq(Time.utc(2024, 1, 15, 10, 30, 0))
+    end
+
+    it "parses a fractional time with a non-zero offset" do
+      Build::TimeFormat.parse?("2024-01-15T10:30:00.5+02:00").try(&.to_utc)
+        .should eq(Time.utc(2024, 1, 15, 8, 30, 0, nanosecond: 500_000_000))
+    end
+
+    it "returns nil for an empty string instead of raising" do
+      Build::TimeFormat.parse?("").should be_nil
+    end
+
+    it "returns nil for nil instead of raising" do
+      Build::TimeFormat.parse?(nil).should be_nil
+    end
+
+    it "returns nil for unparseable input instead of raising" do
+      Build::TimeFormat.parse?("not-a-time").should be_nil
+      Build::TimeFormat.parse?("2024-13-99").should be_nil
+    end
+
+    it "returns nil for well-formed but out-of-range timestamps (raises ArgumentError, not Format::Error)" do
+      Build::TimeFormat.parse?("2024-02-30T10:00:00Z").should be_nil  # Feb 30
+      Build::TimeFormat.parse?("2024-01-15T25:00:00Z").should be_nil  # hour 25
+      Build::TimeFormat.parse?("2024-13-01T00:00:00Z").should be_nil  # month 13
+    end
+  end
+end

--- a/src/commands/ps.cr
+++ b/src/commands/ps.cr
@@ -1,6 +1,7 @@
 require "term-spinner"
 require "http/web_socket"
 require "base64"
+require "../time_format"
 
 module Build
   module Commands
@@ -45,24 +46,28 @@ module Build
             output.puts("=== #{dyno._type.colorize.green.bold} (#{dyno.size.colorize.cyan.bold}): #{dyno.display.colorize.white.bold} (#{dyno.processes.size.colorize.yellow.bold})")
             dyno.processes.each do |process|
               # output.puts("  #{process.index}: #{process.status} (#{process.started_at}) #{process.restarts} restarts")
-              # Specify the expected format of the timestamp (ISO 8601 in this example)
-              started_at = Time.parse(process.started_at, "%Y-%m-%dT%H:%M:%S.%LZ", location: Time::Location::UTC)
+              # Parse leniently: the API's timestamp shape varies, and an
+              # unparseable value should not crash the whole listing.
+              started_at = Build::TimeFormat.parse?(process.started_at)
               status = process.status == "Running" ? "up".colorize.green : "down".colorize.red
 
-              # dotiw = (Time.utc - started_at).total_seconds.to_i.seconds
-              dotiw = distance_of_time_in_words(started_at)
-
-              entry = "#{dyno._type.colorize(:white)}.#{process.index}: #{status} " +
-                "#{started_at.to_s.colorize(:dark_gray)} (~ #{dotiw.colorize.yellow} ago)"
-
+              when_str = if started_at
+                "#{started_at.to_s.colorize(:dark_gray)} (~ #{distance_of_time_in_words(started_at).colorize.yellow} ago)"
+              else
+                process.started_at.to_s.colorize(:dark_gray).to_s
+              end
+              entry = "#{dyno._type.colorize(:white)}.#{process.index}: #{status} " + when_str
 
               restarts     = process.restarts
               restarted_at = process.restarted_at
               if restarted_at && restarts && restarts > 0
                 entry += " #{process.restarts} restarts"
-                restarted_at_time = Time.parse(restarted_at, "%Y-%m-%dT%H:%M:%S.%LZ", location: Time::Location::UTC)
-                dotiw = distance_of_time_in_words(restarted_at_time)
-                entry += " (last at #{restarted_at.to_s.colorize(:dark_gray)} ~ #{dotiw.colorize.yellow} ago)"
+                if restarted_at_time = Build::TimeFormat.parse?(restarted_at)
+                  dotiw = distance_of_time_in_words(restarted_at_time)
+                  entry += " (last at #{restarted_at.to_s.colorize(:dark_gray)} ~ #{dotiw.colorize.yellow} ago)"
+                else
+                  entry += " (last at #{restarted_at.to_s.colorize(:dark_gray)})"
+                end
               end
               output.puts entry
             end

--- a/src/time_format.cr
+++ b/src/time_format.cr
@@ -1,0 +1,22 @@
+module Build
+  # Lenient parsing of API timestamps for display.
+  #
+  # The API returns ISO 8601 / RFC 3339 timestamps, but the exact shape varies
+  # (with or without fractional seconds, `Z` vs a numeric offset). Parsing with
+  # a single hardcoded format string raises on any variant it doesn't match,
+  # which previously crashed whole listings (e.g. `ps`) on one odd row.
+  #
+  # `parse?` accepts any ISO 8601 timestamp and returns `nil` on anything it
+  # can't parse, so callers can degrade gracefully instead of raising.
+  module TimeFormat
+    def self.parse?(value : String?) : Time?
+      return nil if value.nil? || value.empty?
+      Time.parse_iso8601(value)
+    rescue Time::Format::Error | ArgumentError
+      # Time::Format::Error: malformed input. ArgumentError: well-formed but
+      # out-of-range (e.g. "2024-02-30T..." or hour 25), which parse_iso8601
+      # raises from Time.local after tokenizing successfully.
+      nil
+    end
+  end
+end


### PR DESCRIPTION
`ps:list` parsed `started_at`/`restarted_at` with a single hardcoded format
string (`%Y-%m-%dT%H:%M:%S.%LZ`). Any timestamp that didn't match exactly — no
fractional seconds, a numeric offset instead of `Z`, or a well-formed but
out-of-range value — raised and crashed the entire process listing.

Adds `Build::TimeFormat.parse?`, which accepts any ISO 8601 timestamp and
returns `nil` on anything unparseable (catching both `Time::Format::Error` and
the `ArgumentError` that `parse_iso8601` raises for out-of-range values). `ps`
now degrades to showing the raw timestamp instead of crashing.

Testing: new `spec/time_format_spec.cr` covers fractional/offset/garbage and the
out-of-range ArgumentError path; full suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)