### PR TITLE
Correct oidc-login command annotation

### DIFF
--- a/src/commands/oidc_login.cr
+++ b/src/commands/oidc_login.cr
@@ -10,7 +10,7 @@ require "netrc"
 # accepts the authorization, the command polls the Build API to get the user's token.
 module Build
   module Commands
-    @[ACONA::AsCommand("run")]
+    @[ACONA::AsCommand("oidc-login")]
     class OidcLogin < Base
       protected def configure : Nil
         self


### PR DESCRIPTION
`OidcLogin` was annotated `@[ACONA::AsCommand("run")]`, a copy-paste from the
`run` command. It's harmless today because commands are registered eagerly in
`build_cli.cr` and the `.name("oidc-login")` call wins, but the duplicate "run"
annotation is a latent footgun if registration ever moves to the annotation.
Points it at `"oidc-login"` to match the command.

Testing: build + spec pass; `bld list` shows both `run` and `oidc-login`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)