### PR TITLE
Add opt-out GitHub release update check

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,6 +92,10 @@ Conventions to follow:
 - `BUILD_API_KEY` — bearer token, bypasses `~/.netrc`.
 - `BUILD_DEFAULT_REGION` — default `us-east-1`.
 - `DEBUG=1` — verbose CLI + SDK logging.
+- `BUILD_NO_UPDATE_CHECK=1` — disable the once-per-day GitHub release check
+  that prints an "update available" notice on STDERR. State is piggybacked on
+  `~/.netrc` as a synthetic `bld-update-check` machine entry, so no additional
+  dotfile is created. See `src/update_check.cr`.
 
 ## Note: `bld skills`
 

--- a/spec/update_check_spec.cr
+++ b/spec/update_check_spec.cr
@@ -47,6 +47,41 @@ describe Build::UpdateCheck do
         io.to_s.should be_empty
       end
     end
+
+    it "skips when io is not a TTY (non-interactive)" do
+      # IO::Memory.tty? is false, so this exercises the interactivity gate.
+      io = IO::Memory.new
+      Build::UpdateCheck.check!("1.0.0", io)
+      io.to_s.should be_empty
+    end
+  end
+
+  describe ".fast_path?" do
+    it "detects --version / --help / _complete in ARGV" do
+      {"--version", "-V", "--help", "-h", "_complete"}.each do |token|
+        original = ARGV.dup
+        begin
+          ARGV.clear
+          ARGV << token
+          Build::UpdateCheck.fast_path?.should be_true
+        ensure
+          ARGV.clear
+          original.each { |a| ARGV << a }
+        end
+      end
+    end
+
+    it "is false for normal command invocations" do
+      original = ARGV.dup
+      begin
+        ARGV.clear
+        ARGV << "apps:list"
+        Build::UpdateCheck.fast_path?.should be_false
+      ensure
+        ARGV.clear
+        original.each { |a| ARGV << a }
+      end
+    end
   end
 end
 

--- a/spec/update_check_spec.cr
+++ b/spec/update_check_spec.cr
@@ -1,0 +1,74 @@
+require "./spec_helper"
+require "../src/update_check"
+
+describe Build::UpdateCheck do
+  describe ".newer?" do
+    it "compares patch, minor, major" do
+      Build::UpdateCheck.newer?("1.1.79", "1.1.78").should be_true
+      Build::UpdateCheck.newer?("1.2.0", "1.1.99").should be_true
+      Build::UpdateCheck.newer?("2.0.0", "1.99.99").should be_true
+      Build::UpdateCheck.newer?("1.1.78", "1.1.78").should be_false
+      Build::UpdateCheck.newer?("1.1.77", "1.1.78").should be_false
+    end
+
+    it "handles differing segment counts and pre-release/build metadata" do
+      Build::UpdateCheck.newer?("1.2", "1.2.0").should be_false
+      Build::UpdateCheck.newer?("1.2.0.1", "1.2.0").should be_true
+      Build::UpdateCheck.newer?("1.2.3-rc.1", "1.2.3").should be_false
+      Build::UpdateCheck.newer?("1.2.3+build.5", "1.2.3").should be_false
+    end
+  end
+
+  describe ".disabled?" do
+    it "is true when BUILD_NO_UPDATE_CHECK is set to a truthy value" do
+      with_env({"BUILD_NO_UPDATE_CHECK" => "1"}) { Build::UpdateCheck.disabled?.should be_true }
+    end
+
+    it "treats 0/false/empty/unset as not disabled" do
+      {nil, "", "0", "false"}.each do |v|
+        with_env({"BUILD_NO_UPDATE_CHECK" => v}) do
+          Build::UpdateCheck.disabled?.should be_false
+        end
+      end
+    end
+  end
+
+  describe ".check!" do
+    it "skips on non-numeric versions" do
+      io = IO::Memory.new
+      Build::UpdateCheck.check!("dev", io)
+      io.to_s.should be_empty
+    end
+
+    it "skips when disabled" do
+      with_env({"BUILD_NO_UPDATE_CHECK" => "1"}) do
+        io = IO::Memory.new
+        Build::UpdateCheck.check!("1.0.0", io)
+        io.to_s.should be_empty
+      end
+    end
+  end
+end
+
+# Runs a block with env overrides, then restores.
+def with_env(overrides, &)
+  previous = {} of String => String?
+  overrides.each do |key, value|
+    k = key.to_s
+    previous[k] = ENV[k]?
+    if value.nil?
+      ENV.delete(k)
+    else
+      ENV[k] = value
+    end
+  end
+  yield
+ensure
+  previous.try &.each do |k, v|
+    if v.nil?
+      ENV.delete(k)
+    else
+      ENV[k] = v
+    end
+  end
+end

--- a/src/build_cli.cr
+++ b/src/build_cli.cr
@@ -1,6 +1,7 @@
 require "athena-console"
 require "./utils"
 require "./log_colorizer"
+require "./update_check"
 require "./commands/base"
 require "./commands/**"
 require "uri"
@@ -123,6 +124,11 @@ application.add Build::Commands::Domains::Clear.new
 application.add Build::Commands::Domains::Info.new
 application.add Build::Commands::Domains::Update.new
 application.add Build::Commands::Domains::Wait.new
+
+# Check for a newer released version on GitHub. Cached to at most one
+# request per day and silently no-ops on any failure or when disabled via
+# BUILD_NO_UPDATE_CHECK.
+Build::UpdateCheck.check!(VERSION)
 
 # Run the application.
 # By default this uses STDIN and STDOUT for its input and output.

--- a/src/update_check.cr
+++ b/src/update_check.cr
@@ -8,25 +8,63 @@ module Build
   # every attempt (success or failure) so a bad network cannot cause every
   # invocation to re-fetch. Disable with BUILD_NO_UPDATE_CHECK=1.
   #
-  # State is piggybacked onto ~/.netrc as a synthetic entry — no extra
-  # dotfile for the user to find:
+  # State is stored as an extended attribute on the user's ~/.netrc:
   #
-  #   machine bld-update-check
-  #     login  <RFC3339 timestamp of last attempt>
-  #     password <latest release version, or "none" if the attempt failed>
+  #   user.io.build.update-check = "<RFC3339 timestamp>|<version or 'none'>"
+  #
+  # This keeps the state cost-free (no extra dotfile, no separate lockfile)
+  # and — critically — never touches the netrc's contents, so nothing we do
+  # here can corrupt the user's auth tokens. Individual setxattr/getxattr
+  # calls are atomic in the kernel, so no locking is needed either.
+  #
+  # Fallback strategy: if we can't persist the state (Windows, or a
+  # filesystem like FAT/exFAT that returns ENOTSUP from setxattr), the
+  # check is skipped entirely rather than run without back-off. Without a
+  # working persistent cache we would otherwise hit GitHub on every
+  # invocation, which is exactly the "hammering when offline" behavior
+  # we're trying to avoid. Users on those platforms simply don't get
+  # update notices — that's the correct trade.
+  #
+  # Startup latency is bounded by TOTAL_BUDGET. HTTP::Client's connect and
+  # read timeouts don't cover the blocking getaddrinfo DNS lookup, so a
+  # captive portal or dead resolver could otherwise hang startup for the OS
+  # DNS timeout (many seconds). We work around this by running the fetch in
+  # a fiber and racing it against `select`'s timeout, and by pre-recording
+  # a "none" result *before* the fetch so back-off is guaranteed even if
+  # the process is killed mid-hang.
   module UpdateCheck
-    GITHUB_REPO    = "buildio/cli"
-    RELEASE_URL    = "https://api.github.com/repos/#{GITHUB_REPO}/releases/latest"
-    CACHE_TTL      = 24.hours
-    # Deliberately tight — below the ~200ms "the tool is slow" threshold.
-    TIMEOUT        = 200.milliseconds
-    NETRC_MACHINE  = "bld-update-check"
-    NO_VERSION     = "none"
-    DISABLE_VAR    = "BUILD_NO_UPDATE_CHECK"
+    GITHUB_REPO  = "buildio/cli"
+    RELEASE_URL  = "https://api.github.com/repos/#{GITHUB_REPO}/releases/latest"
+    CACHE_TTL    = 24.hours
+    # Wall-clock cap on how long we'll block the CLI waiting for the fetch.
+    # If exceeded the fetch fiber keeps running in the background — it may
+    # still populate the cache before the process exits, which surfaces the
+    # notice on the next invocation.
+    TOTAL_BUDGET = 700.milliseconds
+    # Backup timeouts on the TCP connect and each socket read once DNS is done.
+    IO_TIMEOUT   = 500.milliseconds
+    # user.* namespace is required by Linux for non-root xattr writes and is
+    # accepted by macOS without special handling.
+    XATTR_NAME   = "user.io.build.update-check"
+    NO_VERSION   = "none"
+    DISABLE_VAR  = "BUILD_NO_UPDATE_CHECK"
+    # Argv tokens that indicate a fast/non-interactive path where the check
+    # would add user-visible latency for no benefit (shell completion) or
+    # where the user is asking a specific quick question (--version / --help).
+    SKIP_ARGV    = {"_complete", "--version", "-V", "--help", "-h"}
 
     def self.check!(current : String, io : IO = STDERR) : Nil
-      return if disabled? || !(current =~ /^\d+\.\d+\.\d+/)
-      latest = cached { fetched = fetch; record(fetched); fetched }
+      return if disabled? || !interactive?(io) || fast_path?
+      return unless current =~ /^\d+\.\d+\.\d+/
+      entry = read_entry
+      latest =
+        if entry && Time.utc - entry[:checked_at] <= CACHE_TTL
+          # Fresh — trust the record even if it's "none" (means the last
+          # attempt failed and we're still within the back-off window).
+          entry[:latest_version]
+        else
+          refresh
+        end
       io.puts notice(current, latest) if latest && newer?(latest, current)
     rescue
       # Never surface an error to the user.
@@ -37,31 +75,63 @@ module Build
       !!val && !val.empty? && val != "0" && val.downcase != "false"
     end
 
-    # Yields to fetch a fresh version only when the last attempt is stale
-    # or missing. Returns the version to use (nil if last attempt failed).
-    def self.cached(& : -> String?) : String?
-      if (entry = read_entry) && Time.utc - entry[:checked_at] <= CACHE_TTL
-        entry[:latest_version]
-      else
-        yield
-      end
+    # An interactive TTY is a prerequisite: notices to a redirected STDERR
+    # would be invisible, and non-TTY contexts (CI, subshells running
+    # completion) shouldn't pay the network latency.
+    def self.interactive?(io : IO) : Bool
+      io.responds_to?(:tty?) && io.tty?
+    end
+
+    # Skip on shell completion and on --version / --help, which are the
+    # quick-answer paths where an extra HTTP round-trip is most annoying.
+    def self.fast_path? : Bool
+      ARGV.any? { |a| SKIP_ARGV.includes?(a) }
     end
 
     def self.read_entry : NamedTuple(checked_at: Time, latest_version: String?)?
-      entry = Netrc.read[NETRC_MACHINE]
-      return nil unless entry
-      ts = Time.parse_rfc3339(entry.login)
-      version = entry.password == NO_VERSION ? nil : entry.password
-      {checked_at: ts, latest_version: version}
+      raw = read_xattr(netrc_path)
+      return nil unless raw
+      ts_str, sep, version = raw.partition('|')
+      return nil if ts_str.empty? || sep.empty?
+      ts = Time.parse_rfc3339(ts_str)
+      latest = version == NO_VERSION ? nil : version
+      {checked_at: ts, latest_version: latest}
     rescue
       nil
+    end
+
+    # Refresh the cached "latest" version with a strict wall-clock budget.
+    # Pre-records "none" so a hang or DNS block that outlives startup still
+    # counts toward back-off. The fetch fiber records its own result so that
+    # if it eventually beats the process exit (but not our budget), the next
+    # invocation still gets the notice.
+    #
+    # If the pre-record fails (xattrs unsupported), skip the network fetch
+    # entirely: without a working back-off cache we'd hit GitHub on every
+    # invocation, which is worse than not checking at all.
+    def self.refresh : String?
+      return nil unless record(nil)
+      ch = Channel(String?).new(1)
+      spawn do
+        result = fetch
+        record(result) if result
+        ch.send(result)
+      rescue
+        ch.send(nil)
+      end
+      select
+      when result = ch.receive
+        result
+      when timeout(TOTAL_BUDGET)
+        nil
+      end
     end
 
     def self.fetch : String?
       uri = URI.parse(RELEASE_URL)
       client = HTTP::Client.new(uri)
-      client.connect_timeout = TIMEOUT
-      client.read_timeout = TIMEOUT
+      client.connect_timeout = IO_TIMEOUT
+      client.read_timeout = IO_TIMEOUT
       res = client.get(uri.request_target, headers: HTTP::Headers{
         "Accept" => "application/vnd.github+json", "User-Agent" => "bld-cli-update-check",
       })
@@ -73,14 +143,24 @@ module Build
       client.try &.close rescue nil
     end
 
-    # Records this attempt in ~/.netrc so failures don't retry until the
-    # TTL elapses. Nil is stored as "none" (netrc password can't be empty).
-    def self.record(latest : String?) : Nil
-      netrc = Netrc.read
-      netrc[NETRC_MACHINE] = {Time.utc.to_rfc3339, latest || NO_VERSION}
-      netrc.save
+    # Persists a new attempt as an xattr on the netrc file. Nil is stored as
+    # "none" to distinguish "we tried and failed" from "we never tried".
+    # Returns true iff the xattr was written; callers use false to mean
+    # "we have no working back-off cache — skip the network entirely".
+    def self.record(latest : String?) : Bool
+      path = netrc_path
+      # Ensure the netrc exists so we have something to attach an xattr to.
+      # Match the perms bld login itself would create.
+      unless File.exists?(path)
+        File.open(path, "w", 0o600) { }
+      end
+      write_xattr(path, "#{Time.utc.to_rfc3339}|#{latest || NO_VERSION}")
     rescue
-      # Missing / bad-permission / unwritable netrc — silently skip.
+      false
+    end
+
+    def self.netrc_path : String
+      Netrc.default_path
     end
 
     def self.newer?(latest : String, current : String) : Bool
@@ -101,6 +181,62 @@ module Build
         s << "  https://github.com/" << GITHUB_REPO << "/releases/tag/v" << latest << "\n"
         s << "  Set BUILD_NO_UPDATE_CHECK=1 to disable this check.\n"
       end
+    end
+
+    # --- xattr syscall bindings ------------------------------------------
+    #
+    # Linux and macOS both expose setxattr/getxattr but with different
+    # signatures (macOS has an extra `position` and `options`). Everything
+    # else compiles to a no-op.
+
+    {% if flag?(:darwin) %}
+      # libSystem is already linked implicitly; no @[Link(...)] needed.
+      lib LibXattr
+        fun setxattr(path : LibC::Char*, name : LibC::Char*, value : Void*, size : LibC::SizeT, position : UInt32, options : Int32) : Int32
+        fun getxattr(path : LibC::Char*, name : LibC::Char*, value : Void*, size : LibC::SizeT, position : UInt32, options : Int32) : LibC::SSizeT
+      end
+    {% elsif flag?(:linux) %}
+      lib LibXattr
+        fun setxattr(path : LibC::Char*, name : LibC::Char*, value : Void*, size : LibC::SizeT, flags : Int32) : Int32
+        fun getxattr(path : LibC::Char*, name : LibC::Char*, value : Void*, size : LibC::SizeT) : LibC::SSizeT
+      end
+    {% end %}
+
+    # Read the xattr as a UTF-8 string, or nil if absent / unsupported.
+    def self.read_xattr(path : String) : String?
+      {% if flag?(:darwin) || flag?(:linux) %}
+        buf = Bytes.new(256)
+        {% if flag?(:darwin) %}
+          size = LibXattr.getxattr(path, XATTR_NAME, buf.to_unsafe.as(Void*), buf.size, 0_u32, 0)
+        {% else %}
+          size = LibXattr.getxattr(path, XATTR_NAME, buf.to_unsafe.as(Void*), buf.size)
+        {% end %}
+        return nil if size < 0
+        String.new(buf[0, size.to_i])
+      {% else %}
+        nil
+      {% end %}
+    rescue
+      nil
+    end
+
+    # Returns true iff the syscall succeeded. False signals to callers that
+    # this platform/filesystem can't persist state, so the check should be
+    # skipped rather than repeated without back-off.
+    def self.write_xattr(path : String, value : String) : Bool
+      {% if flag?(:darwin) || flag?(:linux) %}
+        bytes = value.to_slice
+        {% if flag?(:darwin) %}
+          rc = LibXattr.setxattr(path, XATTR_NAME, bytes.to_unsafe.as(Void*), bytes.size, 0_u32, 0)
+        {% else %}
+          rc = LibXattr.setxattr(path, XATTR_NAME, bytes.to_unsafe.as(Void*), bytes.size, 0)
+        {% end %}
+        rc == 0
+      {% else %}
+        false
+      {% end %}
+    rescue
+      false
     end
   end
 end

--- a/src/update_check.cr
+++ b/src/update_check.cr
@@ -1,0 +1,106 @@
+require "http/client"
+require "json"
+require "uri"
+require "netrc"
+
+module Build
+  # Once-per-day GitHub release check. Fully silent on any failure. Records
+  # every attempt (success or failure) so a bad network cannot cause every
+  # invocation to re-fetch. Disable with BUILD_NO_UPDATE_CHECK=1.
+  #
+  # State is piggybacked onto ~/.netrc as a synthetic entry — no extra
+  # dotfile for the user to find:
+  #
+  #   machine bld-update-check
+  #     login  <RFC3339 timestamp of last attempt>
+  #     password <latest release version, or "none" if the attempt failed>
+  module UpdateCheck
+    GITHUB_REPO    = "buildio/cli"
+    RELEASE_URL    = "https://api.github.com/repos/#{GITHUB_REPO}/releases/latest"
+    CACHE_TTL      = 24.hours
+    # Deliberately tight — below the ~200ms "the tool is slow" threshold.
+    TIMEOUT        = 200.milliseconds
+    NETRC_MACHINE  = "bld-update-check"
+    NO_VERSION     = "none"
+    DISABLE_VAR    = "BUILD_NO_UPDATE_CHECK"
+
+    def self.check!(current : String, io : IO = STDERR) : Nil
+      return if disabled? || !(current =~ /^\d+\.\d+\.\d+/)
+      latest = cached { fetched = fetch; record(fetched); fetched }
+      io.puts notice(current, latest) if latest && newer?(latest, current)
+    rescue
+      # Never surface an error to the user.
+    end
+
+    def self.disabled? : Bool
+      val = ENV[DISABLE_VAR]?
+      !!val && !val.empty? && val != "0" && val.downcase != "false"
+    end
+
+    # Yields to fetch a fresh version only when the last attempt is stale
+    # or missing. Returns the version to use (nil if last attempt failed).
+    def self.cached(& : -> String?) : String?
+      if (entry = read_entry) && Time.utc - entry[:checked_at] <= CACHE_TTL
+        entry[:latest_version]
+      else
+        yield
+      end
+    end
+
+    def self.read_entry : NamedTuple(checked_at: Time, latest_version: String?)?
+      entry = Netrc.read[NETRC_MACHINE]
+      return nil unless entry
+      ts = Time.parse_rfc3339(entry.login)
+      version = entry.password == NO_VERSION ? nil : entry.password
+      {checked_at: ts, latest_version: version}
+    rescue
+      nil
+    end
+
+    def self.fetch : String?
+      uri = URI.parse(RELEASE_URL)
+      client = HTTP::Client.new(uri)
+      client.connect_timeout = TIMEOUT
+      client.read_timeout = TIMEOUT
+      res = client.get(uri.request_target, headers: HTTP::Headers{
+        "Accept" => "application/vnd.github+json", "User-Agent" => "bld-cli-update-check",
+      })
+      return nil unless res.status_code == 200
+      JSON.parse(res.body)["tag_name"]?.try(&.as_s?).try(&.lchop("v"))
+    rescue
+      nil
+    ensure
+      client.try &.close rescue nil
+    end
+
+    # Records this attempt in ~/.netrc so failures don't retry until the
+    # TTL elapses. Nil is stored as "none" (netrc password can't be empty).
+    def self.record(latest : String?) : Nil
+      netrc = Netrc.read
+      netrc[NETRC_MACHINE] = {Time.utc.to_rfc3339, latest || NO_VERSION}
+      netrc.save
+    rescue
+      # Missing / bad-permission / unwritable netrc — silently skip.
+    end
+
+    def self.newer?(latest : String, current : String) : Bool
+      a = latest.split(/[-+]/, 2).first.split(".")
+      b = current.split(/[-+]/, 2).first.split(".")
+      {a.size, b.size}.max.times do |i|
+        av, bv = a[i]?.try(&.to_i?) || 0, b[i]?.try(&.to_i?) || 0
+        return true if av > bv
+        return false if av < bv
+      end
+      false
+    end
+
+    private def self.notice(current : String, latest : String) : String
+      String.build do |s|
+        s << "\n  A new release of bld is available: "
+        s << current.colorize(:yellow) << " → " << latest.colorize(:green) << "\n"
+        s << "  https://github.com/" << GITHUB_REPO << "/releases/tag/v" << latest << "\n"
+        s << "  Set BUILD_NO_UPDATE_CHECK=1 to disable this check.\n"
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Once per day, check GitHub for a newer `bld` release and print a one-line notice on STDERR when one is available.
- Startup latency is capped by a 700ms wall-clock budget (`spawn` + `select` timeout) that covers the blocking `getaddrinfo` DNS lookup — HTTP::Client's connect/read timeouts alone do not.
- Every attempt (success or failure) is pre-recorded before the fetch so an offline machine, a hang, or a mid-DNS process kill still counts toward the 24h back-off — no hammering GitHub.
- State is stored as an **xattr** on `~/.netrc` (`user.io.build.update-check`) — never modifies the netrc's contents, so the check cannot corrupt auth tokens. No extra dotfile, no separate lockfile.
- Gated on interactivity: skips when STDERR is not a TTY and on fast paths (`--version`, `-V`, `--help`, `-h`, `_complete`).
- Fallback: on platforms without xattr support (Windows) or filesystems that return ENOTSUP (FAT/exFAT), the check is skipped entirely rather than run without back-off.
- Opt out with `BUILD_NO_UPDATE_CHECK=1`.
- Silently no-ops on any exception, dev versions, or when disabled.

## Test plan

- [x] `crystal spec spec/update_check_spec.cr` passes (9 examples, 0 failures — covers version comparison, disabled-env, dev-version, non-TTY skip, and fast-path detection).
- [x] Fresh run with an empty netrc prints the update notice and writes the `user.io.build.update-check` xattr with the RFC3339 timestamp and version. Netrc contents unchanged.
- [x] Second run within 24h reuses the cache — no network call, no netrc/xattr mutation of consequence.
- [x] Simulated offline run bounded well under a second, silently continues, and records `none` in the xattr. A follow-up call within TTL returns fast without retrying the network.
- [x] `BUILD_NO_UPDATE_CHECK=1 bld --version` produces no notice, does not touch the network, and leaves the netrc/xattr untouched.
- [x] `bld --version` (without disable var) still exits fast — the fast-path gate skips the fetch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)