### PR TITLE
Add signup command

### DIFF
--- a/src/build_cli.cr
+++ b/src/build_cli.cr
@@ -65,6 +65,7 @@ application = ACON::Application.new "Build.io CLI", version: VERSION
 
 # Register commands using the `#add` method
 application.add Build::Commands::Whoami.new
+application.add Build::Commands::Signup.new
 application.add Build::Commands::Login.new
 application.add Build::Commands::OidcLogin.new
 {% unless flag?(:win32) %}

--- a/src/commands/signup.cr
+++ b/src/commands/signup.cr
@@ -1,0 +1,53 @@
+require "netrc"
+
+# This command is used to sign up for a Build account entirely from the CLI, so an
+# agent can sign a user up on their behalf with just an email address. It sends the
+# email to the Build API, which sends a verification link to that address. Once the
+# user clicks the link and finishes creating their account, they can authenticate
+# with `bld login`.
+#
+# NOTE: `DefaultApi#signup` does not exist in the generated SDK yet — it is added
+# by a follow-up buildio/sdk-crystal-lang PR, so this file does not compile until
+# that SDK update is pinned.
+module Build
+  module Commands
+    @[ACONA::AsCommand("signup")]
+    class Signup < Base
+      protected def configure : Nil
+        self
+          .name("signup")
+          .description("Sign up for a Build account")
+          .help("This command is used to sign up for a Build account without leaving the terminal. It sends a verification email to the given address. Click the link in the email to finish creating the account, then run `bld login` to authenticate. Note that region access is granted separately, so a newly created account may not have access to any region yet.")
+          .option("email", "e", :required, "The email address to sign up with.")
+          .usage("signup -e user@example.com")
+      end
+      def execute(input : ACON::Input::Interface, output : ACON::Output::Interface) : ACON::Command::Status
+        email = input.option("email")
+        unless email
+          output.puts "<error>   Missing required option --email</error>"
+          return ACON::Command::Status::FAILURE
+        end
+
+        begin
+          # Signup is unauthenticated, so build the client directly instead of
+          # going through Base#api, which exits when no token is stored.
+          api_instance = Build::DefaultApi.new
+          api_instance.signup(email)
+        rescue e : Build::ApiError
+          error_message = begin
+            JSON.parse(e.message.to_s)["error"].to_s
+          rescue
+            e.message
+          end
+          output.puts("Signup failed: #{error_message}".colorize(:red))
+          return ACON::Command::Status::FAILURE
+        end
+
+        output.puts "Verification email sent to #{email.colorize(:green)}."
+        output.puts "Click the link in the email to finish creating your account, then run #{"bld login".colorize(:cyan)} to authenticate."
+        output.puts "Note: region access is granted separately — a new account may not have access to any region yet."
+        return ACON::Command::Status::SUCCESS
+      end
+    end
+  end
+end

--- a/src/commands/skills.cr
+++ b/src/commands/skills.cr
@@ -74,6 +74,11 @@ module Build
 
         --- Authentication ---
 
+        bld signup -e user@example.com         # Sign up (sends a verification
+                                               # email; run `bld login` after).
+                                               # Region access is granted
+                                               # separately — a new account may
+                                               # not have access to any region.
         bld login                              # Browser-based OAuth login
         bld whoami                             # Show current user
 


### PR DESCRIPTION
## Summary

Adds `bld signup -e user@example.com`, a fully CLI-driven signup so an agent can sign a user up on their behalf with just an email address.

- Calls `Build::DefaultApi#signup(email)`, which sends a verification link to that address
- No auto-login: the user clicks the link to finish creating the account, then runs `bld login` to authenticate
- Output notes that region access is granted separately, so a new account may not have access to any region yet
- Signup is unauthenticated, so the command builds `Build::DefaultApi` directly rather than going through `Base#api` (which exits when no token is stored)
- On `Build::ApiError`, shows the response body's `error` JSON field (falling back to the raw message) and exits non-zero
- Registers the command in `build_cli.cr` and documents it in `bld skills` per AGENTS.md

## ⚠️ Does not compile yet — SDK dependency

`DefaultApi#signup` does not exist in the generated SDK yet. It is added by a follow-up `buildio/sdk-crystal-lang` PR that should reference this PR. Until that SDK update is pinned here, this branch fails to build — expected and intentional per the agreed workflow (CLI side first, SDK/server side after).

Expected generated method (mirroring `oidc_login`): `DefaultApi#signup(email : String? = nil)` — raises `Build::ApiError` on non-2xx, where the error body may contain a JSON `"error"` message for display.

## Test plan

- [x] `bld signup --help` and missing `--email` error path verified against a locally built binary (prior raw-HTTP iteration; command wiring unchanged)
- [ ] `shards build` / `crystal spec` once the SDK adds `signup`
- [ ] End-to-end verification against the real endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)
