### PR TITLE
Update term-spinner.

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -38,5 +38,5 @@ shards:
 
   term-spinner:
     git: https://github.com/crystal-term/spinner.git
-    version: 1.0.0
+    version: 1.0.0+git.commit.a65ca1a204736393cd701dc0f65af8154cb93912
 

--- a/shard.yml
+++ b/shard.yml
@@ -12,6 +12,7 @@ dependencies:
     version: 1.1.38
   term-spinner:
     github: crystal-term/spinner
+    commit: a65ca1a204736393cd701dc0f65af8154cb93912
   netrc:
     github: usiegj00/crystal-netrc
   ssh2:


### PR DESCRIPTION
This fixes a build issue during the brew install phase of `Error: undefined method 'send' for Nil`