### PR TITLE
Fix spinner crash on Crystal 1.21 (execution contexts)

### DIFF
--- a/src/build_cli.cr
+++ b/src/build_cli.cr
@@ -1,4 +1,5 @@
 require "athena-console"
+require "./ext/term_spinner"
 require "./utils"
 require "./log_colorizer"
 require "./update_check"
@@ -7,7 +8,12 @@ require "./commands/**"
 require "uri"
 
 VERSION = {{ `shards version #{__DIR__}`.chomp.stringify }}
-Colorize.on_tty_only! # Don't colorize output if not on a TTY
+# Don't colorize output if not on a TTY. This is the default behaviour since
+# Crystal 1.17 (crystal-lang/crystal#15881), which also deprecated
+# `Colorize.on_tty_only!`, so only call it on the older compilers we support.
+{% if compare_versions(Crystal::VERSION, "1.17.0") < 0 %}
+  Colorize.on_tty_only!
+{% end %}
 
 module Build
   private DEFAULT_API_URL = "https://app.build.io"

--- a/src/ext/term_spinner.cr
+++ b/src/ext/term_spinner.cr
@@ -1,0 +1,34 @@
+require "term-spinner"
+
+# Crystal 1.21 released execution contexts and made them the default: the
+# runtime now starts a `Fiber::ExecutionContext::Parallel` context, whose
+# scheduler rejects `spawn(same_thread: true)` with
+#
+#   Fiber::ExecutionContext::Parallel::Scheduler#spawn doesn't support same_thread:true
+#
+# term-spinner still spawns its animation fiber with `same_thread: true`, so
+# every `auto_spin` (e.g. `bld login`) aborts when the CLI is compiled with
+# Crystal >= 1.21. Redefine `auto_spin` with a plain `spawn`, which behaves
+# identically on every Crystal version we support. Drop this file once
+# term-spinner ships the fix upstream.
+module Term
+  class Spinner
+    def auto_spin
+      start
+      sleep_time = @interval
+
+      spin
+      spawn do
+        sleep(sleep_time)
+        until stopped?
+          sleep(sleep_time)
+          spin unless paused?
+        end
+      end
+    ensure
+      if @hide_cursor
+        write(Term::Cursor.show, false)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## The bug

`bld login` aborts as soon as the spinner starts:

```
? Press any key to open up the browser to login or q to exit
Opening browser to https://app.build.io/cli_auth/authorize/…
In n/a line n/a:
  Fiber::ExecutionContext::Parallel::Scheduler#spawn doesn't support same_thread:true
```

## Root cause

Crystal **1.21.0** (2026-07-16) shipped Execution Contexts as a breaking change. The runtime now always starts a `Fiber::ExecutionContext::Parallel` context, and `spawn(same_thread:)` was deprecated — that scheduler raises a `RuntimeError` instead of honouring it.

`term-spinner` animates with `spawn(same_thread: true)` (`src/term-spinner.cr:221`), so `Term::Spinner#auto_spin` blows up. Athena renders the RuntimeError as the `In n/a line n/a:` box.

This hits **Homebrew users only**: the formula builds `bld` from source with whatever Crystal is installed, and brew now ships 1.21.0. Linux release binaries pin `crystallang/crystal:1.19.1-alpine` in the `Dockerfile` and are fine. It is not related to the recent term-spinner pin bump — `same_thread: true` was there in v1.0.0 too.

Affected call sites: `login`, plus every `dots_spinner` user — `ps`, `run`, `pipelines`.

## Fix

- `src/ext/term_spinner.cr` reopens `Term::Spinner` and redefines `auto_spin` with a plain `spawn`. The default execution context has parallelism 1, so behaviour is identical on every Crystal we support. Delete the file once the fix lands upstream — PR opened at crystal-term/spinner#5.
- While in `build_cli.cr`: `Colorize.on_tty_only!` is deprecated on 1.17+ (TTY-only colorizing became the default in crystal-lang/crystal#15881). It is now only called on older compilers, via a `compare_versions` guard, so the declared `crystal: ">= 1.16.1"` floor still holds. Build is warning-free again.

## Verification

Against the real 1.21.0 toolchain (downloaded standalone, system Crystal untouched at 1.20.3):

- Reproduced the crash with unpatched term-spinner — identical message and stack frame.
- Patched `auto_spin` and the `dots_spinner()` helper both run clean on 1.21.
- Full `crystal build src/build_cli.cr` succeeds with **zero warnings** on 1.21.0 and 1.20.3.
- `crystal spec` — 77 examples, 0 failures.
- Ran the 1.21-built binary's `bld login` against a dead API URL with a stubbed `open`: the spinner animates and the flow proceeds to the network call, instead of aborting.
- Colorize behaviour unchanged: escape codes present on a TTY, absent when piped.

## Follow-up

The fix reaches users only after a release — Homebrew builds from the tagged tarball, so brew users stay broken until v1.1.84 ships and the formula is bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
