### PR TITLE
Guard Signal::WINCH with win32 flag to fix Windows build

### DIFF
--- a/src/commands/ps.cr
+++ b/src/commands/ps.cr
@@ -274,11 +274,13 @@ module Build
           terminal = ACON::Terminal.new
           self.send_cable(ws, identifier, {type: "resize", cols: terminal.width, rows: terminal.height})
 
-          # Handle terminal resize
-          Signal::WINCH.trap do
-            t = ACON::Terminal.new
-            self.send_cable(ws, identifier, {type: "resize", cols: t.width, rows: t.height}) rescue nil
-          end
+          # Handle terminal resize (SIGWINCH is Unix-only)
+          {% unless flag?(:win32) %}
+            Signal::WINCH.trap do
+              t = ACON::Terminal.new
+              self.send_cable(ws, identifier, {type: "resize", cols: t.width, rows: t.height}) rescue nil
+            end
+          {% end %}
 
           # Enter raw mode and stream stdin
           STDIN.noecho do


### PR DESCRIPTION
Signal::WINCH is a Unix-only concept and causes a compile error on Windows. Wrap it in {% unless flag?(:win32) %}, matching the existing pattern in run.cr.